### PR TITLE
Improve TTS and Kobold streaming behavior

### DIFF
--- a/ai/chat.py
+++ b/ai/chat.py
@@ -12,6 +12,8 @@ from ai.memory import get_conversation_context, get_user_memory
 from config import *
 from typing import Dict, Any
 
+ENABLE_REDUCED_SYSTEM_PROMPT = globals().get("ENABLE_REDUCED_SYSTEM_PROMPT", False)
+
 # Import enhanced KoboldCPP connection manager
 try:
     from ai.kobold_connection_manager import EnhancedKoboldCPPManager, maintain_consciousness_during_error
@@ -349,7 +351,7 @@ def get_current_brisbane_time():
         }
 
 def ask_kobold_streaming(messages, max_tokens=MAX_TOKENS):
-    """✅ SMART RESPONSIVE: Wait for 40-50% completion or first complete phrase"""
+    """Stream tokens from KoboldCPP as they arrive"""
     payload = {
         "model": "llama3",
         "messages": messages,
@@ -357,221 +359,50 @@ def ask_kobold_streaming(messages, max_tokens=MAX_TOKENS):
         "temperature": TEMPERATURE,
         "stream": True
     }
-    
-    try:
-        print(f"[SmartResponsive] 🎭 Starting smart responsive streaming to: {KOBOLD_URL}")
-        
-        # Use enhanced manager for streaming if available
-        if ENHANCED_KOBOLD_MANAGER_AVAILABLE:
-            try:
-                response = _enhanced_kobold_manager.execute_request(payload, stream=True)
-            except Exception as e:
-                print(f"[SmartResponsive] ⚠️ Enhanced manager failed, falling back: {e}")
-                # Fall back to legacy implementation
-                def _execute_streaming_request():
-                    session = _get_http_session()
-                    return session.post(
-                        KOBOLD_URL, 
-                        json=payload, 
-                        timeout=60,
-                        stream=True
-                    )
-                
-                response = _kobold_manager.execute_request(_execute_streaming_request)
-        else:
-            # Legacy implementation
-            def _execute_streaming_request():
-                session = _get_http_session()
-                return session.post(
-                    KOBOLD_URL, 
-                    json=payload, 
-                    timeout=60,
-                    stream=True
-                )
-            
-            response = _kobold_manager.execute_request(_execute_streaming_request)
-        
-        if response.status_code == 200:
-            buffer = ""
-            word_count = 0
-            chunk_count = 0
-            first_chunk_sent = False
-            estimated_total_words = max_tokens // 1.3  # Rough estimate of final word count
-            
-            # ✅ SMART THRESHOLDS: Wait for natural completion
-            MIN_WORDS_FOR_FIRST_CHUNK = 8              # Minimum words before considering first chunk
-            TARGET_COMPLETION_PERCENTAGE = 0.45        # Target 45% completion
-            TARGET_WORDS = int(estimated_total_words * TARGET_COMPLETION_PERCENTAGE)
-            
-            print(f"[SmartResponsive] 🎯 Targeting 40-50% completion (~{TARGET_WORDS} words) or first complete phrase")
-            
-            for line in response.iter_lines():
-                if line:
-                    line_text = line.decode('utf-8')
-                    
-                    if not line_text.strip() or line_text.startswith(':'):
-                        continue
-                    
-                    if line_text.startswith('data: '):
-                        data_content = line_text[6:]
-                        
-                        if data_content.strip() == '[DONE]':
-                            break
-                        
-                        try:
-                            chunk_data = json.loads(data_content)
-                            
-                            if 'choices' in chunk_data and len(chunk_data['choices']) > 0:
-                                choice = chunk_data['choices'][0]
-                                
-                                content = ""
-                                if 'delta' in choice and 'content' in choice['delta']:
-                                    content = choice['delta']['content']
-                                elif 'message' in choice and 'content' in choice['message']:
-                                    content = choice['message']['content']
-                                
-                                if content:
-                                    buffer += content
-                                    word_count = len(buffer.split())
-                                    
-                                    # ✅ SMART FIRST CHUNK: Wait for natural break OR target completion
-                                    if not first_chunk_sent and word_count >= MIN_WORDS_FOR_FIRST_CHUNK:
-                                        
-                                        # Priority 1: Look for complete sentences (best option)
-                                        sentence_match = re.search(r'^(.*?[.!?])\s+', buffer)
-                                        if sentence_match:
-                                            first_chunk = sentence_match.group(1).strip()
-                                            if len(first_chunk.split()) >= 4:  # Ensure meaningful length
-                                                chunk_count += 1
-                                                first_chunk_sent = True
-                                                print(f"[SmartResponsive] 📝 SMART first chunk (complete sentence): '{first_chunk}'")
-                                                yield first_chunk
-                                                buffer = buffer[sentence_match.end():].strip()
-                                                continue
-                                        
-                                        # Priority 2: Look for natural phrase breaks (comma, etc.)
-                                        phrase_patterns = [
-                                            r'^(.*?,)\s+',           # After comma
-                                            r'^(.*?;\s+)',           # After semicolon
-                                            r'^(.*?:\s+)',           # After colon
-                                            r'^(.*?\s+and\s+)',      # Before "and"
-                                            r'^(.*?\s+but\s+)',      # Before "but"
-                                            r'^(.*?\s+so\s+)',       # Before "so"
-                                            r'^(.*?\s+because\s+)',  # Before "because"
-                                            r'^(.*?\s+however\s+)',  # Before "however"
-                                        ]
-                                        
-                                        for pattern in phrase_patterns:
-                                            phrase_match = re.search(pattern, buffer)
-                                            if phrase_match:
-                                                first_chunk = phrase_match.group(1).strip()
-                                                if len(first_chunk.split()) >= 5:  # Ensure meaningful phrase
-                                                    chunk_count += 1
-                                                    first_chunk_sent = True
-                                                    print(f"[SmartResponsive] 🎭 SMART first chunk (natural phrase): '{first_chunk}'")
-                                                    yield first_chunk
-                                                    buffer = buffer[phrase_match.end():].strip()
-                                                    break
-                                        
-                                        # Priority 3: Wait for target completion percentage
-                                        if not first_chunk_sent and word_count >= TARGET_WORDS:
-                                            # Take a reasonable chunk that doesn't cut words
-                                            words = buffer.split()
-                                            # Find a good breaking point (not in the middle of a word)
-                                            chunk_size = min(12, len(words))  # Up to 12 words
-                                            first_chunk = ' '.join(words[:chunk_size])
-                                            
-                                            # Ensure we don't cut off mid-sentence awkwardly
-                                            if not first_chunk.endswith(('.', '!', '?', ',', ';', ':')):
-                                                # Look for a better breaking point
-                                                for i in range(chunk_size-1, 4, -1):  # Work backwards
-                                                    test_chunk = ' '.join(words[:i])
-                                                    if test_chunk.endswith((',', ';', ':')):
-                                                        first_chunk = test_chunk
-                                                        chunk_size = i
-                                                        break
-                                            
-                                            chunk_count += 1
-                                            first_chunk_sent = True
-                                            completion_pct = (word_count / estimated_total_words) * 100
-                                            print(f"[SmartResponsive] 📊 SMART first chunk (target completion {completion_pct:.1f}%): '{first_chunk}'")
-                                            yield first_chunk
-                                            buffer = ' '.join(words[chunk_size:])
-                                    
-                                    # ✅ SUBSEQUENT CHUNKS: Continue with natural breaks
-                                    elif first_chunk_sent:
-                                        # Complete sentences (highest priority)
-                                        sentence_endings = re.finditer(r'([.!?]+)\s+', buffer)
-                                        last_end = 0
-                                        
-                                        for match in sentence_endings:
-                                            sentence = buffer[last_end:match.end()].strip()
-                                            if sentence and len(sentence.split()) >= 3:
-                                                chunk_count += 1
-                                                print(f"[SmartResponsive] 📝 Sentence chunk {chunk_count}: '{sentence}'")
-                                                yield sentence
-                                                last_end = match.end()
-                                        
-                                        buffer = buffer[last_end:]
-                                        
-                                        # Natural phrase breaks (second priority)
-                                        current_words = len(buffer.split())
-                                        if current_words >= 8:  # Wait for reasonable chunk size
-                                            pause_patterns = [
-                                                r'([^.!?]*?,)\s+',        # Up to comma
-                                                r'([^.!?]*?;\s+)',        # Up to semicolon
-                                                r'([^.!?]*?:\s+)',        # Up to colon
-                                                r'([^.!?]*?\s+and\s+)',   # Up to "and"
-                                                r'([^.!?]*?\s+but\s+)',   # Up to "but"
-                                                r'([^.!?]*?\s+so\s+)',    # Up to "so"
-                                            ]
-                                            
-                                            for pattern in pause_patterns:
-                                                matches = list(re.finditer(pattern, buffer))
-                                                if matches:
-                                                    last_match = matches[-1]
-                                                    chunk_text = last_match.group(1).strip()
-                                                    if len(chunk_text.split()) >= 4:
-                                                        chunk_count += 1
-                                                        print(f"[SmartResponsive] 🎭 Natural pause chunk {chunk_count}: '{chunk_text}'")
-                                                        yield chunk_text
-                                                        buffer = buffer[last_match.end():]
-                                                        break
-                        
-                        except json.JSONDecodeError:
-                            continue
-            
-            # ✅ Send any remaining content as final chunk
-            if buffer.strip():
-                final_chunk = buffer.strip()
-                if len(final_chunk.split()) >= 2:
-                    chunk_count += 1
-                    print(f"[SmartResponsive] 🏁 Final chunk {chunk_count}: '{final_chunk}'")
-                    yield final_chunk
-            
-            print(f"[SmartResponsive] ✅ Smart responsive streaming complete - {chunk_count} natural chunks")
-                    
-        else:
-            print(f"[SmartResponsive] ❌ HTTP Error {response.status_code}: {response.text}")
-            # Generate dynamic error response through LLM
-            error_context = {
-                'error_type': 'connection_error',
-                'error_code': response.status_code,
-                'situation': 'streaming_response'
-            }
-            error_response = _generate_dynamic_error_response(error_context)
-            yield error_response
-            
-    except Exception as e:
-        print(f"[SmartResponsive] ❌ Error: {e}")
-        # Generate dynamic error response through LLM
-        error_context = {
-            'error_type': 'general_error',
-            'error_message': str(e),
-            'situation': 'streaming_response'
-        }
-        error_response = _generate_dynamic_error_response(error_context)
-        yield error_response
+
+    for attempt in range(2):
+        try:
+            response = requests.post(
+                KOBOLD_URL,
+                json=payload,
+                timeout=10,
+                stream=True
+            )
+            break
+        except requests.RequestException as e:
+            if attempt == 0:
+                print(f"[SmartResponsive] ⚠️ request failed, retrying once: {e}")
+                continue
+            else:
+                print(f"[SmartResponsive] ❌ request failed: {e}")
+                return
+
+    if response.status_code != 200:
+        print(f"[SmartResponsive] ❌ HTTP Error {response.status_code}: {response.text}")
+        return
+
+    for line in response.iter_lines():
+        if not line:
+            continue
+        line_text = line.decode('utf-8')
+        if not line_text.startswith('data: '):
+            continue
+        data_content = line_text[6:]
+        if data_content.strip() == '[DONE]':
+            break
+        try:
+            chunk_data = json.loads(data_content)
+        except json.JSONDecodeError:
+            continue
+        if 'choices' in chunk_data and len(chunk_data['choices']) > 0:
+            choice = chunk_data['choices'][0]
+            content = ""
+            if 'delta' in choice and 'content' in choice['delta']:
+                content = choice['delta']['content']
+            elif 'message' in choice and 'content' in choice['message']:
+                content = choice['message']['content']
+            if content:
+                yield content
 
 def ask_kobold(messages, max_tokens=MAX_TOKENS):
     """Original non-streaming KoboldCpp request (kept for compatibility)"""
@@ -851,9 +682,12 @@ def generate_response_streaming(question, username, lang=DEFAULT_LANG):
             compressed_system_msg = compress_prompt("", context_data)
         
         print(f"[ChatStream] 🗜️ Using compressed prompt: {len(compressed_system_msg)} chars (~{estimate_tokens(compressed_system_msg)} tokens)")
-        
+
         # Store compressed version for internal use, expand for LLM
-        system_msg = expand_prompt(compressed_system_msg, context_data)
+        if ENABLE_REDUCED_SYSTEM_PROMPT:
+            system_msg = "You are Buddy, an AI assistant."
+        else:
+            system_msg = expand_prompt(compressed_system_msg, context_data)
 
         messages = [
             {"role": "system", "content": system_msg},
@@ -1076,9 +910,12 @@ def generate_response(question, username, lang=DEFAULT_LANG):
             compressed_system_msg = compress_prompt("", context_data)
         
         print(f"[Chat] 🗜️ Using compressed prompt: {len(compressed_system_msg)} chars (~{estimate_tokens(compressed_system_msg)} tokens)")
-        
+
         # Store compressed version for internal use, expand for LLM
-        system_msg = expand_prompt(compressed_system_msg, context_data)
+        if ENABLE_REDUCED_SYSTEM_PROMPT:
+            system_msg = "You are Buddy, an AI assistant."
+        else:
+            system_msg = expand_prompt(compressed_system_msg, context_data)
 
         messages = [
             {"role": "system", "content": system_msg},


### PR DESCRIPTION
## Summary
- Run Kokoro TTS HTTP request in a background thread with dual-stage timeouts and log fallback on failure
- Stream KoboldCPP tokens directly with 10s timeout, single retry, and optional reduced system prompt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', pytz, requests)*

------
https://chatgpt.com/codex/tasks/task_e_68981a168618832883b38e18c280bffe