### PR TITLE
Add audio grace window and normalize streaming playback

### DIFF
--- a/audio/full_duplex_manager.py
+++ b/audio/full_duplex_manager.py
@@ -123,6 +123,11 @@ class FullDuplexManager:
         with self.interrupt_lock:
             return self.speech_interrupted
 
+    def clear_interrupt(self):
+        """Clear any pending interrupt"""
+        with self.interrupt_lock:
+            self.speech_interrupted = False
+
     def start(self):
         """Start the turn-based manager"""
         if self.running:


### PR DESCRIPTION
## Summary
- gate duplex interrupts with a configurable 350ms grace window
- serialize Kokoro TTS requests with a module lock and normalize audio to 48kHz mono int16
- expose `clear_interrupt` on full_duplex_manager and log playback events

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy', No module named 'pytz', No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689823b8c0e083289adc41555ddab9ac